### PR TITLE
Fix: exit retry loop in get_belief after a successful attempt

### DIFF
--- a/src/beliefs.py
+++ b/src/beliefs.py
@@ -1122,6 +1122,7 @@ def get_belief(
             distribution = belief_cls.parse_response(response, weight=weight, **prior_params_or_none)
             # Compute and store the mean belief
             mean_belief = distribution.get_mean_belief()
+            break
         except Exception as e:
             if attempt == n_retries - 1:
                 print(f"Querying LLM: ERROR: {e}\nMax retries reached. Returning empty distribution.")


### PR DESCRIPTION
## Summary

The retry loop in `get_belief()` (`src/beliefs.py`) has no `break` on success, so every belief elicitation runs all `n_retries` (default 3) attempts even when the first one succeeds. Each attempt queries the LLM with `n_samples` (default 30) completions, and only the last attempt's result is kept.

In effect, every prior and posterior computation costs 3x the LLM calls and 3x the wall-clock time it should, with no impact on the result (the earlier successful responses are simply discarded and resampled).

## Fix

Add `break` after a successful attempt, so retries only happen on exceptions — which appears to be the original intent, given the `except` branch's retry messaging.

## How this was found

While tracing a full run of the pipeline we noticed each belief distribution was logged three times with fresh samples, e.g. a single node's prior elicitation produced three consecutive 30-sample batches before the pipeline moved on.